### PR TITLE
:rocket: feat(orders): improve filtering by responsible, area, and roles

### DIFF
--- a/app/Http/Controllers/Api/AreaController.php
+++ b/app/Http/Controllers/Api/AreaController.php
@@ -19,7 +19,4 @@ class AreaController extends Controller
 
         return response()->json($areas);
     }
-
-    
-
 }

--- a/app/Http/Controllers/Api/StaffController.php
+++ b/app/Http/Controllers/Api/StaffController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Responsible;
+use Illuminate\Http\Request;
+
+class StaffController extends Controller
+{
+    public function filterStaff(Request $request)
+    {
+        $conexion = 'sqlsrv_' . $request->input('company');
+
+        $staff = Responsible::on($conexion)
+                    ->get()
+                    ->map(function ($f) {
+                        return [
+                            'id'   => $f->RESPONSABLE_CODIGO,
+                            'name' => $f->RESPONSABLE_NOMBRE,
+                        ];
+                    });
+
+        return response()->json($staff);
+    }
+}

--- a/app/Models/Area.php
+++ b/app/Models/Area.php
@@ -9,23 +9,47 @@ use Illuminate\Database\Eloquent\Model;
 class Area extends Model
 {
     use HasFactory, HasDynamicConnection;
-    
+
     protected $table = 'AREA';
     protected $primaryKey = 'AREA_CODIGO';
     protected $keyType = 'string';
     public $timestamps = false;
 
-    protected $appends = ['id', 'name'];
 
-    protected $hidden = ['AREA_CODIGO', 'AREA_DESCRIPCION'];
-
-    public function getIdAttribute()
-    {
-        return $this->attributes['AREA_CODIGO'];
+    public static function getAvailableAreas(
+    string $connectionName,
+    string $dateStart,
+    string $dateEnd,
+    ?string $responsible = null,
+    ?string $type = null
+) {
+    if ($type === 'OC') {
+        $tables = ['COMOVC'];
+    } elseif ($type === 'OS') {
+        $tables = ['COMOVC_S'];
+    } else {
+        $tables = ['COMOVC', 'COMOVC_S'];
     }
 
-    public function getNameAttribute()
-    {
-        return $this->attributes['AREA_DESCRIPCION'];
+    $results = collect();
+
+    foreach ($tables as $table) {
+        $rows = self::on($connectionName)
+            ->from($table)
+            ->join('REQUISC as R', "$table.OC_CNRODOCREF", '=', 'R.NROREQUI')
+            ->join('AREA as A', 'R.AREA', '=', 'A.AREA_CODIGO') // 👈 join con tabla de áreas
+            ->select('A.AREA_CODIGO as id', 'A.AREA_DESCRIPCION as name')
+            ->whereIn("$table.OC_CSITORD", ['01', '03', '04'])
+            ->whereBetween("$table.OC_DFECDOC", [$dateStart, $dateEnd]);
+
+        if ($responsible) {
+            $rows->where("$table.OC_CSOLICT", $responsible);
+        }
+
+        $results = $results->concat($rows->distinct()->get());
     }
+
+    return $results->unique('id')->values();
+}
+
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\Product\FamilyController;
 use App\Http\Controllers\Api\Product\TypeController;
 use App\Http\Controllers\Api\ProductController;
 use App\Http\Controllers\Api\ReportController;
+use App\Http\Controllers\Api\StaffController;
 use App\Http\Controllers\Api\SupplierController;
 use App\Http\Controllers\Api\UserController;
 use Illuminate\Http\Request;
@@ -25,6 +26,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::get('/families', [FamilyController::class, 'show']);
     Route::get('/types', [TypeController::class, 'show']);
     Route::get('/areas', [AreaController::class, 'filterCompany']);
+    Route::get('/staff', [StaffController::class, 'filterStaff']);
 
     Route::controller(SupplierController::class)
         ->prefix('suppliers')


### PR DESCRIPTION
- Se agregó filtrado basado en roles:
  - GERENTE y ADMINISTRADOR pueden ver órdenes de todos los responsables.
  - Otros usuarios están restringidos a su user_code asignado en CompanyUserPivot.
- Se corrigió la obtención de user_code asegurando que user_id se corresponda correctamente con la empresa seleccionada.
- Se implementó el método getAvailableAreas para devolver solo las áreas que realmente tienen OCs/OS en el rango de fechas seleccionado, en lugar de cargar todas.
- Se unificó el formato de respuesta de áreas a { id, name } para un uso consistente en el frontend.
- Se optimizaron las consultas de resumen reduciendo carga innecesaria mediante distinct y agrupamiento adecuado.
- Se agregó logging para depurar el rol de usuario y la obtención de userCode.

Estos cambios aseguran que:

- Gerentes/Admins puedan analizar datos globales.
- Usuarios regulares estén restringidos a su responsabilidad asignada.
- Las áreas disponibles se limiten dinámicamente a los datos reales en el período seleccionado.
- El frontend muestre correctamente las etiquetas en los selects.