### PR TITLE
Corrección de color en los chips de estado

### DIFF
--- a/resources/js/pages/ocs.vue
+++ b/resources/js/pages/ocs.vue
@@ -353,7 +353,6 @@ const showSnackbar = ({ message, color = 'success' }) => {
           <div class="d-flex flex-column">
             <VChip
               :color="getStatusColor(item.status)"
-              class="text-white"
               outlined
             >
               {{

--- a/resources/js/views/apps/product/view/ProductTabOverview.vue
+++ b/resources/js/views/apps/product/view/ProductTabOverview.vue
@@ -67,7 +67,7 @@ const status = ref([
 ]);
 
 function getStatusColor(value) {
-  const s = status.value.find((s) => s.value === value);
+  const s = status.value.find((s) => s.value == value);
   return s ? s.color : "grey";
 }
 
@@ -280,7 +280,6 @@ watch(stats, (newStats) => {
               <div class="d-flex flex-column">
                 <VChip
                   :color="getStatusColor(item.status)"
-                  class="text-white"
                   outlined
                 >
                   {{

--- a/resources/js/views/apps/supplier/view/SupplierTabOverview.vue
+++ b/resources/js/views/apps/supplier/view/SupplierTabOverview.vue
@@ -282,7 +282,6 @@ watch(stats, (newStats) => {
               <div class="d-flex flex-column">
                 <VChip
                   :color="getStatusColor(item.status)"
-                  class="text-white"
                   outlined
                 >
                   {{


### PR DESCRIPTION
Se eliminó la clase text-white del componente <VChip> que causaba problemas de visibilidad en el tema claro.
Ahora los colores de los chips se ajustan correctamente al tema activo (claro u oscuro).

Cambios realizados:

- Eliminación de text-white del chip de estado.
- Verificación de compatibilidad con los temas light/dark.

Resultado esperado:
Los chips muestran los colores correctos según su estado (EMITIDA, APROBADA, RECHAZADO) y el tema activo.